### PR TITLE
small fix in  to allow language-specific feat set

### DIFF
--- a/src/clustergen/do_clustergen
+++ b/src/clustergen/do_clustergen
@@ -998,6 +998,9 @@ then
     if grep -q "state names" festival/clunits/mcep.desc-old
     then
        true
+    elif [ -f ${FESTVOXDIR}/src/vox_files/${FV_LANG}/mcep.desc ]
+    then
+       cp -p $FESTVOXDIR/src/vox_files/${FV_LANG}/mcep.desc festival/clunits/mcep.desc-old
     else
        cp -p $FESTVOXDIR/src/clustergen/mcep.desc festival/clunits/mcep.desc-old
     fi


### PR DESCRIPTION
generate_statenames copies in mcep.desc containing default features. We first search for mcep.desc in lang directory instead